### PR TITLE
支持新的密码套件参数

### DIFF
--- a/vpn/tunnel.go
+++ b/vpn/tunnel.go
@@ -41,7 +41,7 @@ func initTunnel() {
 
     // https://gitlab.com/openconnect/ocserv/-/blob/master/src/worker-http.c#L150
     // https://github.com/openconnect/openconnect/blob/master/gnutls-dtls.c#L75
-    reqHeaders["X-DTLS12-CipherSuite"] = "ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:AES128-GCM-SHA256"
+    reqHeaders["X-DTLS12-CipherSuite"] = "ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384:ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-RSA-AES128-GCM-SHA256:AES128-GCM-SHA256"
 }
 
 // SetupTunnel initiates an HTTP CONNECT command to establish a VPN


### PR DESCRIPTION
添加了2个密码套件参数 `ECDHE-ECDSA-AES256-GCM-SHA384:ECDHE-RSA-AES256-GCM-SHA384`

另外客户端连接的时候，是不是得明确使用服务端返回的密码套件，参考返回参数 `X-DTLS12-CipherSuite`